### PR TITLE
Add AWS S3 dependencies to spark-operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 COPY hack/gencerts.sh /usr/bin/
 
+# Setup dependencies for AWS S3 access
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.4/hadoop-aws-2.7.4.jar $SPARK_HOME/jars
+RUN chmod 644 $SPARK_HOME/jars/hadoop-aws-2.7.4.jar
+ADD https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar $SPARK_HOME/jars
+RUN  chmod 644 $SPARK_HOME/jars/aws-java-sdk-1.7.4.jar
+
 COPY entrypoint.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]


### PR DESCRIPTION
This adds ability to use s3 path for spark dependencies